### PR TITLE
search.select.js修改

### DIFF
--- a/src/component/search.select.js
+++ b/src/component/search.select.js
@@ -69,7 +69,7 @@ class SearchSelect extends React.Component {
                                             active: this.state.selected.indexOf(value) > -1
                                         })}
                                         onClick={this.handleSelect.bind(this, value)}>
-                                        {value.name}
+                                        {value.name} {value.id ? ' ( ' + value.id + ' )' : ''}
                                         {this.state.selected.indexOf(value) > -1 ? (
                                             <i className="glyphicon glyphicon-ok text-success pull-right"/>
                                         ) : undefined}


### PR DESCRIPTION
因为有时候不仅仅需要用到name，还需要在下拉列表中显示 id。
比如冷链搜索用户的时候，需要同时显示name 和 id。

当然现在这个**pr**是临时解决的办法，我的想法是通过`undersccore`的 `_.pick`方法，而外部props传入一个数组，比如`['name', 'id']`，然后就会选择渲染`name`和`id`了，而不是像现在这样写死`{value.name}`。
