### PR TITLE
filter select sm size

### DIFF
--- a/demo/doc/FilterSearchSelect.md
+++ b/demo/doc/FilterSearchSelect.md
@@ -80,7 +80,7 @@ class FilterSearchSelect1 extends React.Component {
                     selected={this.state.selected}
                     onSelect={::this.handleSelect}
                     onFilter={::this.handleFilter}
-                    className="gm-filter-select-sm"
+                    className="gm-search-select-sm"
                 />
 
                 <FilterSearchSelect
@@ -90,7 +90,7 @@ class FilterSearchSelect1 extends React.Component {
                     selected={this.state.selected}
                     onSelect={::this.handleSelect}
                     onFilter={::this.handleFilter}
-                    className="gm-filter-select-sm"
+                    className="gm-search-select-sm"
                 />
             </div>
         );

--- a/demo/doc/FilterSearchSelect.md
+++ b/demo/doc/FilterSearchSelect.md
@@ -80,6 +80,7 @@ class FilterSearchSelect1 extends React.Component {
                     selected={this.state.selected}
                     onSelect={::this.handleSelect}
                     onFilter={::this.handleFilter}
+                    className="gm-filter-select-sm"
                 />
 
                 <FilterSearchSelect
@@ -89,6 +90,7 @@ class FilterSearchSelect1 extends React.Component {
                     selected={this.state.selected}
                     onSelect={::this.handleSelect}
                     onFilter={::this.handleFilter}
+                    className="gm-filter-select-sm"
                 />
             </div>
         );

--- a/demo/doc/nav.config.js
+++ b/demo/doc/nav.config.js
@@ -38,6 +38,9 @@ class NavConfig extends React.Component {
                         <small>级联选择</small>
                     </a></li>
                     <li><a href="#/doc/DropSelect">DropSelect</a></li>
+                    <li><a href="#/doc/FilterSearchSelect">FilterSearchSelect
+                        <small>搜索选择</small>
+                    </a></li>
                     <li><a href="#/doc/FilterSelect">FilterSelect
                         <small>搜索选择v2</small>
                     </a></li>

--- a/src/component/search_select/search.select.js
+++ b/src/component/search_select/search.select.js
@@ -312,11 +312,13 @@ class SearchSelect extends React.Component {
     }
 
     render() {
+        var classnameProps = this.props.className && this.props.className.split(' ');
         return (
             <div
                 ref={ref => this.searchSelect = ref}
-                className={classNames("gm-search-select", this.props.className, {
-                    "gm-search-select-disabled": this.props.disabled
+                className={classNames("gm-search-select", {
+                    "gm-search-select-disabled": this.props.disabled,
+                    "gm-filter-select-sm": classnameProps && (classnameProps.indexOf('gm-filter-select-sm') > -1)
                 })}
             >
                 <Flex wrap className="gm-search-select-input">

--- a/src/component/search_select/search.select.js
+++ b/src/component/search_select/search.select.js
@@ -312,13 +312,11 @@ class SearchSelect extends React.Component {
     }
 
     render() {
-        var classnameProps = this.props.className && this.props.className.split(' ');
         return (
             <div
                 ref={ref => this.searchSelect = ref}
-                className={classNames("gm-search-select", {
-                    "gm-search-select-disabled": this.props.disabled,
-                    "gm-filter-select-sm": classnameProps && (classnameProps.indexOf('gm-filter-select-sm') > -1)
+                className={classNames("gm-search-select", this.props.className, {
+                    "gm-search-select-disabled": this.props.disabled
                 })}
             >
                 <Flex wrap className="gm-search-select-input">

--- a/src/component/search_select/style.less
+++ b/src/component/search_select/style.less
@@ -91,12 +91,9 @@
 
 }
 
-.gm-filter-select-sm {
+.gm-search-select-sm{
   .gm-search-select-input {
     height: 28px;
     padding: 5px 10px;
-    font-size: 12px;
-    line-height: 1.5;
-    border-radius: 0;
   }
 }

--- a/src/component/search_select/style.less
+++ b/src/component/search_select/style.less
@@ -91,9 +91,12 @@
 
 }
 
-.gm-search-select-sm{
+.gm-search-select-sm {
   .gm-search-select-input {
     height: 28px;
     padding: 5px 10px;
+    font-size: 12px;
+    line-height: 1.5;
+    border-radius: 0;
   }
 }

--- a/src/component/search_select/style.less
+++ b/src/component/search_select/style.less
@@ -90,3 +90,13 @@
   }
 
 }
+
+.gm-filter-select-sm {
+  .gm-search-select-input {
+    height: 28px;
+    padding: 5px 10px;
+    font-size: 12px;
+    line-height: 1.5;
+    border-radius: 0;
+  }
+}


### PR DESCRIPTION
1、思路：
直接在组件调用处使用 
`className="gm-search-select-sm"`

假设有 `gm-search-select-sm` 类选择器，则覆盖成

```
gm-search-select-sm {
  .gm-search-select-input {
    height: 28px;
    padding: 5px 10px;
  }
 }
```
为了覆盖原本代码的 
```
.gm-search-select-input {
    padding: 6px 20px 6px 12px;
}
```


设置 height 此时整个 box 是 30 (border:2)，选择区域别处的输入框使用 imput-sm 时 box 也是 30, 为了
 box 一致，所以此处设置 28。


2、看到文档上没有 filter-search-select 组件的入口，就加了一个