### PR TITLE
update cascader_select

### DIFF
--- a/demo/doc/CascaderSelect.md
+++ b/demo/doc/CascaderSelect.md
@@ -236,3 +236,4 @@ class CascaderSelect5 extends React.Component {
 - `selectRender (func)` 自定义已选择渲染
 - `inputProps (object)` 定义里面input的props
 - `disabled (bool)` 禁用CascaderSelect
+- `valueRender (func)` 自定义value的展现

--- a/src/component/cascader/cascader.select.js
+++ b/src/component/cascader/cascader.select.js
@@ -113,7 +113,7 @@ class CascaderSelect extends React.Component {
     }
 
     render() {
-        const {disabled, inputProps} = this.props;
+        const {disabled, inputProps, valueRender} = this.props;
         return (
             <div className={classnames("gm-cascader-select", {
                 "disabled": disabled
@@ -132,6 +132,7 @@ class CascaderSelect extends React.Component {
                     ))}
                     <Flex flex column onKeyDown={::this.handleKeyDown}>
                         <Cascader
+                            valueRender={valueRender}
                             inputProps={inputProps}
                             disabled={disabled}
                             data={this.props.data}
@@ -153,7 +154,8 @@ CascaderSelect.propTypes = {
     multiple: PropTypes.bool,
     selectedRender: PropTypes.func,
     inputProps: PropTypes.object,
-    disabled: PropTypes.bool
+    disabled: PropTypes.bool,
+	valueRender: PropTypes.func
 };
 CascaderSelect.defaultProps = {
     inputProps: {},


### PR DESCRIPTION
cascader_select 单选时会有bug, 当没有完全selected一个item时，不应该显示信息在上面，举个例子：

比如搜索的时候，如果没完全选中一个item，但还是显示在input上，用户会误以为是按照显示的信息来搜索，但其实组件的selected仍然为null。

so，添加一个valueRender，向后兼容的同时又可以业务上自定义去解决这个问题





