### PR TITLE
fixed select

### DIFF
--- a/src/component/select/select.js
+++ b/src/component/select/select.js
@@ -33,7 +33,7 @@ class Select extends React.Component {
         const target = e.target;
         const selectDOM = findDOMNode(this);
 
-        if (!contains(selectDOM, target)) {
+        if (this.state.show && !contains(selectDOM, target)) {
             this.setState({show: false});
         }
     }


### PR DESCRIPTION
场景一:
```javascript
<div>
  <div>
    <input type="radio" onChange={this.handleRadioChange}/>
    <p>test0x00</p>
  </div>
  <div>
    <input type="radio" onChange={this.handleRadioChange}/>
    <p>test0x01</p>
  </div>
</div>
```
场景二:
```javascript
<div>
  <div>
    <input type="radio" onChange={this.handleRadioChange}/>
    <p>test0x00</p>
  </div>
  <div>
    <input type="radio" onChange={this.handleRadioChange}/>
    <p>test0x01</p>
    <Select value="test" onChange={this.handleSelectChange}>
      <Option value="test">test0x01</Option>
    </Select>
  </div>
</div>
```

当遇到`场景一`的时候，点击radio，触发handleRadioChange，会正常切换radio，但是如果添加了`<Select/>`组件，比如遇到`场景二`的时候，就会发现radio的切换失灵了。

为什么会出现这种情况，仔细看Select组件的源码，就会发现组件内部有一个`handleBodyClick`方法，它会监听`body`的click事件，当`!contains(selectDOM, target)`为true的时候，就会setState，触发react组件的重新渲染。

理论上body监听到click事件后，事件会继续以`捕获`的方式传递给子节点，但在`场景二`中因为setState，重新渲染了，handleRadioChange事件就没有生效。


给Select组件添加`this.state.show`判断后，可修复场景二造成的bug

```javasript
if (this.state.show && !contains(selectDOM, target)) {
    this.setState({show: false});
  }
```

我的猜测：
点击radio时会先触发handleBodyClick，如果此时this.state.show为false，不会setState，则继续将事件传递给childNodes，正常触发handleRadioChange，如果this.state.show为true，且!contains(selectDOM, target)也为true，则会触发setState，这样handleRadioChange就失效了。


bug原因：不加`this.state.show`判断，始终会触发`setState`